### PR TITLE
remove ref_ptr move ctors

### DIFF
--- a/include/osg/ref_ptr
+++ b/include/osg/ref_ptr
@@ -36,9 +36,7 @@ class ref_ptr
         ref_ptr() : _ptr(0) {}
         ref_ptr(T* ptr) : _ptr(ptr) { if (_ptr) _ptr->ref(); }
         ref_ptr(const ref_ptr& rp) : _ptr(rp._ptr) { if (_ptr) _ptr->ref(); }
-#if __cplusplus >= 201103L
-        ref_ptr(ref_ptr&& rp) noexcept : _ptr(rp._ptr) { rp._ptr = 0; }
-#endif
+
         template<class Other> ref_ptr(const ref_ptr<Other>& rp) : _ptr(rp._ptr) { if (_ptr) _ptr->ref(); }
         ref_ptr(observer_ptr<T>& optr) : _ptr(0) { optr.lock(*this); }
         ~ref_ptr() { if (_ptr) _ptr->unref();  _ptr = 0; }
@@ -54,17 +52,6 @@ class ref_ptr
             assign(rp);
             return *this;
         }
-
-#if __cplusplus >= 201103L
-        template<class Other> ref_ptr& operator = (ref_ptr<Other>&& rp)
-        {
-            if (_ptr == rp._ptr) return *this;
-            if (_ptr != nullptr) _ptr->unref();
-            _ptr = rp._ptr;
-            rp._ptr = nullptr;
-            return *this;
-        }
-#endif
 
         inline ref_ptr& operator = (T* ptr)
         {


### PR DESCRIPTION
fixes a crash in release mode on msvc 2022.
reverts 61e04183adea0fc6284c2c4dbf1d5a0144b26f1a